### PR TITLE
Fix: Jade plugin extension functionality

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ const getTemplate = (customTemplatePath = null) => {
 
 
 
-const createTemplate = (settingsBase, templateExtension = null) => {
+const createRenderer = (pluginJadeOptions, templateExtension = null) => {
 
   /* Note regarding Base Settings. It allow the user to set options
   documented in the Jade docs here http://jade-lang.com/api.
@@ -70,12 +70,10 @@ const createTemplate = (settingsBase, templateExtension = null) => {
   optional high-level options with this automatically resolved
   low-level option. */
 
-  const [
-        filename,
-        source ] = getTemplate(templateExtension)
-  const settings = merge({}, { filename }, settingsBase)
-  const template = Jade.compile(source, settings)
-  return template
+  const [ filename, source ] = getTemplate(templateExtension)
+  const jadeOptions = merge({}, { filename }, pluginJadeOptions)
+  const render = Jade.compile(source, jadeOptions)
+  return render
 }
 
 
@@ -149,9 +147,9 @@ const create = (customConfig = {}) => {
 
       if (Utils.isHotMode(c)) F.mapObj(entries, Utils.addChunkDevServer)
 
-      /* Generate the Jade template. */
+      /* Generate the Jade rendering function. */
 
-      const template = createTemplate(config.templateExtension)
+      const render = createRenderer(config.compile, config.templateExtension)
 
       /* Generate the HTML */
 
@@ -164,7 +162,7 @@ const create = (customConfig = {}) => {
           /* If there is only one entry we use the special name `index` which
           browsers will automatically load when no file is given in the URI. */
           const fileName = isSingleEntry ? 'index.html' : `${templateSettings.name}.html`
-          Utils.addAssetHTML(c.assets, fileName, template(templateSettings))
+          Utils.addAssetHTML(c.assets, fileName, render(templateSettings))
         })
       )(entries)
 


### PR DESCRIPTION
Currently, the function that creates the Jade render function is always being called with an extension template value of `null`. This change fixes the call site of `createRenderer` to pass the `compile` settings object and the extension template to the Jade compiler.

I also made some naming changes, as I was getting confused about our terminology vs the Jade terminology — namely `createTemplate` → `createRenderer`, since that's how [the Jade api](http://jade-lang.com/api/) refers to it.
